### PR TITLE
numpy python module is now ported as a .NET static class

### DIFF
--- a/src/Numpy.Bare/np.module.gen.cs
+++ b/src/Numpy.Bare/np.module.gen.cs
@@ -13,7 +13,7 @@ using Numpy.Models;
 
 namespace Numpy
 {
-    public partial class np
+    public static partial class np
     {
         
         public static PyObject self => _lazy_self.Value;

--- a/src/Numpy/np.module.gen.cs
+++ b/src/Numpy/np.module.gen.cs
@@ -14,7 +14,7 @@ using Python.Included;
 
 namespace Numpy
 {
-    public partial class np
+    public static partial class np
     {
         
         public static PyObject self => _lazy_self.Value;


### PR DESCRIPTION
As per title. this updates the following downstream Numpy.NET files:
- `src\Numpy.Bare\np.module.gen.cs`
- `src\Numpy\np.module.gen.cs`

More info in: 
https://github.com/SciSharp/CodeMinion/pull/8