### PR TITLE
Revise installer due to upstream changes

### DIFF
--- a/src/Numpy/np.module.gen.cs
+++ b/src/Numpy/np.module.gen.cs
@@ -35,9 +35,8 @@ namespace Numpy
         
         private static PyObject InstallAndImport(bool force = false)
         {
-            var installer = new Installer();
-            installer.SetupPython(force).Wait();
-            installer.InstallWheel(typeof(np).Assembly, "numpy-1.16.3-cp37-cp37m-win_amd64.whl").Wait();
+            Installer.SetupPython(force).Wait();
+            Installer.InstallWheel(typeof(np).Assembly, "numpy-1.16.3-cp37-cp37m-win_amd64.whl").Wait();
             PythonEngine.Initialize();
             var mod = Py.Import("numpy");
             return mod;


### PR DESCRIPTION
A breaking change was introduced in the upstream Python.Included, wherein the Installer class was refactored into a static class. I modified the corresponding python setup code in Numpy.NET. I do not have a proper dev environment to test this, but the changes are rather simple. If you can test this, that'll be great.