### PR TITLE
Allow reinit of the np.self property if python engine has shutdown.

### DIFF
--- a/src/CodeMinion.Core/CodeGenerator.cs
+++ b/src/CodeMinion.Core/CodeGenerator.cs
@@ -900,7 +900,7 @@ namespace CodeMinion.Core
             {
                 s.Out($"public static partial class {StaticModuleName}", () =>
                 {
-                    s.Out("public static np()", () =>
+                    s.Out("static np()", () =>
                     {
                         s.Out("ReInitializeLazySelf();");
                     });

--- a/src/CodeMinion.Core/CodeGenerator.cs
+++ b/src/CodeMinion.Core/CodeGenerator.cs
@@ -900,10 +900,15 @@ namespace CodeMinion.Core
             {
                 s.Out($"public static partial class {StaticModuleName}", () =>
                 {
+                    s.Out("public static np()", () =>
+                    {
+                        s.Out("ReInitializeLazySelf();");
+                    });
                     s.Break();
                     s.Out("public static PyObject self => _lazy_self.Value;");
                     s.Break();
-                    s.Out($"private static Lazy<PyObject> _lazy_self = new Lazy<PyObject>(() => ", () =>
+                    s.Out($"private static Lazy<PyObject> _lazy_self = default;"); 
+                    s.Out($"private static void ReInitializeLazySelf() => _lazy_self = new Lazy<PyObject>(() => ", () =>
                     {
                         s.Out("try", () =>
                             {
@@ -925,6 +930,7 @@ namespace CodeMinion.Core
                         s.Out(@"#endif");
                         foreach (var generator in InitializationGenerators)
                             generator(s);
+                        s.Out("PythonEngine.AddShutdownHandler(() => ReInitializeLazySelf());");
                         s.Out("PythonEngine.Initialize();");
                         s.Out($"var mod = Py.Import(\"{PythonModuleName}\");");
                         s.Out("return mod;");

--- a/src/Numpy/np.module.gen.cs
+++ b/src/Numpy/np.module.gen.cs
@@ -18,10 +18,14 @@ namespace Numpy
 {
     public static partial class np
     {
-        
+        static np()
+        {
+            ReInitializeLazySelf(); 
+        }
+
         public static PyObject self => _lazy_self.Value;
-        
-        private static Lazy<PyObject> _lazy_self = new Lazy<PyObject>(() => 
+        private static Lazy<PyObject> _lazy_self = default; 
+        private static void ReInitializeLazySelf() => _lazy_self = new Lazy<PyObject>(() =>
         {
             try
             {
@@ -32,9 +36,8 @@ namespace Numpy
                 // retry to fix the installation by forcing a repair, if Python.Included is used.
                 return InstallAndImport(force: true);
             }
-        }
-        );
-        
+        });
+
         private static PyObject InstallAndImport(bool force = false)
         {
             #if PYTHON_INCLUDED
@@ -43,6 +46,7 @@ namespace Numpy
             #if PYTHON_INCLUDED
             Installer.InstallWheel(typeof(np).Assembly, "numpy-1.21.3-cp310-cp310-win_amd64.whl").Wait();
             #endif
+            PythonEngine.AddShutdownHandler(() => ReInitializeLazySelf()); 
             PythonEngine.Initialize();
             var mod = Py.Import("numpy");
             return mod;

--- a/src/Numpy/np.module.gen.cs
+++ b/src/Numpy/np.module.gen.cs
@@ -20,12 +20,13 @@ namespace Numpy
     {
         static np()
         {
-            ReInitializeLazySelf(); 
+            ReInitializeLazySelf();
         }
-
+        
         public static PyObject self => _lazy_self.Value;
-        private static Lazy<PyObject> _lazy_self = default; 
-        private static void ReInitializeLazySelf() => _lazy_self = new Lazy<PyObject>(() =>
+        
+        private static Lazy<PyObject> _lazy_self = default;
+        private static void ReInitializeLazySelf() => _lazy_self = new Lazy<PyObject>(() => 
         {
             try
             {
@@ -36,8 +37,9 @@ namespace Numpy
                 // retry to fix the installation by forcing a repair, if Python.Included is used.
                 return InstallAndImport(force: true);
             }
-        });
-
+        }
+        );
+        
         private static PyObject InstallAndImport(bool force = false)
         {
             #if PYTHON_INCLUDED
@@ -46,7 +48,7 @@ namespace Numpy
             #if PYTHON_INCLUDED
             Installer.InstallWheel(typeof(np).Assembly, "numpy-1.21.3-cp310-cp310-win_amd64.whl").Wait();
             #endif
-            PythonEngine.AddShutdownHandler(() => ReInitializeLazySelf()); 
+            PythonEngine.AddShutdownHandler(() => ReInitializeLazySelf());
             PythonEngine.Initialize();
             var mod = Py.Import("numpy");
             return mod;


### PR DESCRIPTION
I wanted to suggest the following change to the `np.module.gen.cs`. In the event of a `PythonEngine.Shutdown` event, it makes sense to re-initialize the lazy variable for the `np` static class. I have personally encountered this as an issue when unit testing multiple uses of the `Numpy` library within my own code. This way after the shutdown has happened, if `np.*` is called again, the entire flow is re-initialized. 