### PR TITLE
Dispose of ctypes to fix np.array holding on to memory for too long (fixes #108)

### DIFF
--- a/src/Numpy/Manual/np.array.cs
+++ b/src/Numpy/Manual/np.array.cs
@@ -52,7 +52,8 @@ namespace Numpy
             var ndarray = np.empty(new Shape(@object.Length), dtype: type, order: order); 
             if (@object.Length == 0)
                 return new NDarray<T>(ndarray);
-            long ptr = ndarray.PyObject.ctypes.data;
+            var ctypes = ndarray.PyObject.ctypes;
+            long ptr = ctypes.data;
             switch ((object)@object)
             {
                 case char[] a: Marshal.Copy(a, 0, new IntPtr(ptr), a.Length); break;
@@ -80,6 +81,7 @@ namespace Numpy
                     ndarray.imag = ndimag;
                     break;
             }
+            ctypes.Dispose();
             if (dtype !=null || subok != null || ndmin != null)
                 return new NDarray<T>(np.array(ndarray, dtype:dtype, copy: false, subok: subok, ndmin: ndmin));
             return new NDarray<T>(ndarray);

--- a/src/Numpy/Manual/np.array.cs
+++ b/src/Numpy/Manual/np.array.cs
@@ -42,6 +42,7 @@ namespace Numpy
             if (subok != null) kwargs["subok"] = ToPython(subok);
             if (ndmin != null) kwargs["ndmin"] = ToPython(ndmin);
             dynamic py = self.InvokeMethod("array", args, kwargs);
+            args.Dispose();
             return ToCsharp<NDarray>(py);
         }
 
@@ -82,8 +83,12 @@ namespace Numpy
                     break;
             }
             ctypes.Dispose();
-            if (dtype !=null || subok != null || ndmin != null)
-                return new NDarray<T>(np.array(ndarray, dtype:dtype, copy: false, subok: subok, ndmin: ndmin));
+            if (dtype != null || subok != null || ndmin != null)
+            {
+                var converted = np.array(ndarray, dtype: dtype, copy: false, subok: subok, ndmin: ndmin);
+                ndarray.Dispose();
+                return new NDarray<T>(converted);
+            }
             return new NDarray<T>(ndarray);
         }
 

--- a/test/Numpy.UnitTest/NumPy_array_creation.tests.cs
+++ b/test/Numpy.UnitTest/NumPy_array_creation.tests.cs
@@ -384,6 +384,11 @@ namespace Numpy.UnitTest
                 Assert.IsTrue(getOutstandingMem() > 70_000_000);
                 array.Dispose();
                 Assert.IsTrue(getOutstandingMem() < 1_000_000);
+
+                array = np.array(arr, np.float32);
+                Assert.IsTrue(getOutstandingMem() > 30_000_000);
+                array.Dispose();
+                Assert.IsTrue(getOutstandingMem() < 1_000_000);
             }
         }
 


### PR DESCRIPTION
Not entirely sure why `ctypes` requires explicit disposal but tests show this to be the case.

It is not possible to work-around this issue by calling `array.ctypes.Dispose()`; it probably creates a whole extra reference and only that gets disposed.

This is also why this PR stores `ctypes` in a local: getting it again via either `ndarray.ctypes` or `ndarray.PyObject.ctypes` just to dispose of it does not work.

fix #108